### PR TITLE
Fix paginate

### DIFF
--- a/Sources/WaniKani/WaniKani.swift
+++ b/Sources/WaniKani/WaniKani.swift
@@ -116,7 +116,7 @@ public struct WaniKani {
                 return nil
             }
 
-            var keepTrying = false
+            var keepTrying = true
 
             while keepTrying {
                 keepTrying = false


### PR DESCRIPTION
## Description

This PR makes it so that the paginate call actually starts. Before, `keepTrying` was set to false, so the while loop would fail immediately, causing the stream to never fetch anything.

Fixes # (no issue, this is a one-line fix :) )

## Type of Change

- [x] Bug fix

## How has this been Tested?

```swift
        var count = 0

        do {
            for try await foo in waniKaniApi.paginate(.subjects()) {
                count += foo.count

                print(count)
            }
        } catch {
            print("dead :( \(error)")
        }
```

Before, no values would ever be returned. There's another issue stopping this specific bit of code from working (kana vocabulary is not supported, but I'm working on that now)